### PR TITLE
feat: real model inference — train pipeline + live /predictions/predict

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ DATABASE_URL=
 # -----------------------------------------------------------------------------
 MODEL_ARTIFACTS_PATH=model_artifacts
 DEFAULT_ROLLING_WINDOWS=3,5,10
+# Set to a specific model UUID to override auto-selection (optional)
+# MODEL_ID=
 
 # -----------------------------------------------------------------------------
 # Application Settings (Optional — have sensible defaults)

--- a/scripts/train_baseline.py
+++ b/scripts/train_baseline.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""
+Train a baseline Win/Loss classifier using season stats from the database.
+
+Usage:
+    python scripts/train_baseline.py --train-seasons 2018-2022 --test-season 2023
+    python scripts/train_baseline.py  # defaults: train 2018-2022, test 2023
+
+Requires:
+    DATABASE_URL set in .env or environment pointing to beat-books-data DB.
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sqlalchemy import text
+
+# Ensure project root is on path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.core.config import settings
+from src.core.db_reader import engine
+from src.models.model_registry import ModelRegistry
+from src.models.win_loss_model import WinLossModel
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# Features we diff between teams (team1 - team2)
+FEATURE_COLUMNS = [
+    "pf",       # points for
+    "pa",       # points against (from standings)
+    "yds_off",  # offensive yards
+    "yds_def",  # defensive yards allowed
+    "to_off",   # turnovers committed (offense)
+    "to_def",   # turnovers forced (defense)
+    "mov",      # margin of victory
+    "srs",      # simple rating system
+    "osrs",     # offensive SRS
+    "dsrs",     # defensive SRS
+    "win_pct",  # win percentage
+]
+
+
+def load_season_stats(season: int) -> pd.DataFrame:
+    """Load team stats for a season by joining standings + offense + defense."""
+    query = text("""
+        SELECT
+            s.tm,
+            s.pf,
+            s.pa,
+            s.mov,
+            s.srs,
+            s.osrs,
+            s.dsrs,
+            s.win_pct,
+            COALESCE(o.yds, 0) AS yds_off,
+            COALESCE(o.turnovers, 0) AS to_off,
+            COALESCE(d.yds, 0) AS yds_def,
+            COALESCE(d.turnovers, 0) AS to_def
+        FROM standings s
+        LEFT JOIN team_offense o ON s.tm = o.tm AND s.season = o.season
+        LEFT JOIN team_defense d ON s.tm = d.tm AND s.season = d.season
+        WHERE s.season = :season
+    """)
+    with engine.connect() as conn:
+        df = pd.read_sql(query, conn, params={"season": season})
+    return df
+
+
+def load_games(season: int) -> pd.DataFrame:
+    """Load game results for a season."""
+    query = text("""
+        SELECT winner, loser, pts_w, pts_l
+        FROM games
+        WHERE season = :season AND winner IS NOT NULL AND loser IS NOT NULL
+    """)
+    with engine.connect() as conn:
+        df = pd.read_sql(query, conn, params={"season": season})
+    return df
+
+
+def build_dataset(seasons: list[int]) -> tuple[pd.DataFrame, pd.Series]:
+    """
+    Build training dataset: for each game, create two rows (winner perspective + loser perspective)
+    with feature diffs (team1_stats - team2_stats).
+
+    Returns (X, y) where y=1 means team1 won.
+    """
+    all_X = []
+    all_y = []
+
+    for season in seasons:
+        stats = load_season_stats(season)
+        games = load_games(season)
+
+        if stats.empty or games.empty:
+            logger.warning(f"Season {season}: no data (stats={len(stats)}, games={len(games)})")
+            continue
+
+        stats_dict = {row["tm"]: row for _, row in stats.iterrows()}
+
+        for _, game in games.iterrows():
+            winner = game["winner"]
+            loser = game["loser"]
+
+            if winner not in stats_dict or loser not in stats_dict:
+                continue
+
+            w_stats = stats_dict[winner]
+            l_stats = stats_dict[loser]
+
+            # Row 1: winner as team1 -> label=1
+            row1 = {}
+            for col in FEATURE_COLUMNS:
+                w_val = w_stats.get(col, 0) or 0
+                l_val = l_stats.get(col, 0) or 0
+                row1[f"diff_{col}"] = float(w_val) - float(l_val)
+            all_X.append(row1)
+            all_y.append(1)
+
+            # Row 2: loser as team1 -> label=0
+            row2 = {}
+            for col in FEATURE_COLUMNS:
+                w_val = w_stats.get(col, 0) or 0
+                l_val = l_stats.get(col, 0) or 0
+                row2[f"diff_{col}"] = float(l_val) - float(w_val)
+            all_X.append(row2)
+            all_y.append(0)
+
+        logger.info(f"Season {season}: {len(games)} games -> {len(games)*2} rows")
+
+    if not all_X:
+        raise ValueError("No training data found. Check DATABASE_URL and that data is scraped.")
+
+    return pd.DataFrame(all_X), pd.Series(all_y)
+
+
+def parse_seasons(s: str) -> list[int]:
+    """Parse '2018-2022' or '2018,2019,2020' into list of ints."""
+    if "-" in s and "," not in s:
+        start, end = s.split("-")
+        return list(range(int(start), int(end) + 1))
+    return [int(x.strip()) for x in s.split(",")]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train baseline Win/Loss model")
+    parser.add_argument("--train-seasons", default="2018-2022", help="Training seasons (e.g. 2018-2022)")
+    parser.add_argument("--test-season", default="2023", help="Test season (e.g. 2023)")
+    args = parser.parse_args()
+
+    train_seasons = parse_seasons(args.train_seasons)
+    test_seasons = parse_seasons(args.test_season)
+
+    if not settings.DATABASE_URL:
+        logger.error("DATABASE_URL not set. Copy .env.example to .env and configure it.")
+        sys.exit(1)
+
+    logger.info(f"Training on seasons: {train_seasons}")
+    logger.info(f"Testing on seasons: {test_seasons}")
+
+    # Build datasets
+    logger.info("Building training dataset...")
+    X_train, y_train = build_dataset(train_seasons)
+    logger.info(f"Training set: {len(X_train)} samples, {len(X_train.columns)} features")
+
+    logger.info("Building test dataset...")
+    X_test, y_test = build_dataset(test_seasons)
+    logger.info(f"Test set: {len(X_test)} samples")
+
+    # Train
+    model = WinLossModel(model_variant="baseline", version="1.0.0")
+    model.train(X_train, y_train)
+    logger.info("Model trained successfully")
+
+    # Evaluate
+    metrics = model.evaluate(X_test, y_test)
+    logger.info(f"Test metrics: {metrics}")
+
+    # Register and save
+    registry = ModelRegistry(settings.MODEL_ARTIFACTS_PATH)
+    model_id = registry.register_model(
+        model_type="win_loss_classifier",
+        model_name="logistic_regression",
+        version="1.0.0",
+        hyperparameters=model.hyperparameters,
+        feature_version="1.0.0",
+        train_seasons=train_seasons,
+        test_seasons=test_seasons,
+        metrics=metrics,
+        feature_names=list(X_train.columns),
+        notes=f"Baseline logistic regression. Train: {train_seasons}, Test: {test_seasons}",
+    )
+
+    artifact_path = Path(settings.MODEL_ARTIFACTS_PATH) / f"{model_id}.joblib"
+    model.save(str(artifact_path))
+    logger.info(f"Model saved: {artifact_path}")
+    logger.info(f"Model ID: {model_id}")
+    logger.info(f"Registry: {settings.MODEL_ARTIFACTS_PATH}/registry.json")
+
+    print(f"\nDone! Model ID: {model_id}")
+    print(f"Accuracy: {metrics['accuracy']:.3f}")
+    print(f"Log Loss: {metrics['log_loss']:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
 
     # Model artifacts
     MODEL_ARTIFACTS_PATH: str = "model_artifacts"
+    MODEL_ID: str = ""  # Override to load a specific model; empty = best by accuracy
 
     # Feature engineering
     DEFAULT_ROLLING_WINDOWS: str = "3,5,10"  # game windows for rolling averages

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,17 @@
-from fastapi import FastAPI
+import logging
+
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from src.core.config import settings
+from src.service.model_manager import ModelManager, ModelNotFoundError
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="beat-books-model", version=settings.VERSION)
+
+# Lazy-loaded model manager (loads on first prediction request)
+_manager = ModelManager(settings.MODEL_ARTIFACTS_PATH)
 
 
 # --- Response schemas ---
@@ -24,8 +32,8 @@ class ErrorResponse(BaseModel):
 class PredictionRequest(BaseModel):
     home_team: str
     away_team: str
-    season: int
-    week: int
+    season: int = 2023
+    week: int = 0
 
 
 class PredictionDetail(BaseModel):
@@ -50,6 +58,19 @@ class ModelInfoResponse(BaseModel):
     accuracy: float | None
 
 
+# --- Helpers ---
+
+
+def _confidence_bucket(prob: float) -> str:
+    """Map win probability to a confidence label."""
+    diff = abs(prob - 0.5)
+    if diff >= 0.20:
+        return "high"
+    if diff >= 0.10:
+        return "medium"
+    return "low"
+
+
 # --- Endpoints ---
 
 
@@ -68,27 +89,68 @@ def health() -> HealthResponse:
     responses={503: {"model": ErrorResponse}},
 )
 def predict(request: PredictionRequest) -> PredictionResponse:
-    # TODO: Replace stub with actual model inference
+    try:
+        model = _manager.model
+        meta = _manager.model_meta
+    except ModelNotFoundError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+    # Build features
+    try:
+        from src.core.db_reader import engine
+        from src.service.features_for_inference import build_inference_features
+
+        X = build_inference_features(
+            engine=engine,
+            home_team=request.home_team,
+            away_team=request.away_team,
+            season=request.season,
+            expected_features=model.feature_names,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        logger.warning("Feature build failed, using zero features: %s", e)
+        # Fallback: zero-filled features (still returns a prediction, just less useful)
+        import pandas as pd
+
+        X = pd.DataFrame([{f: 0.0 for f in model.feature_names}])
+
+    # Predict
+    proba = model.predict_proba(X)
+    home_win_prob = float(proba[0, 1])
+    winner = request.home_team if home_win_prob >= 0.5 else request.away_team
+
     return PredictionResponse(
         home_team=request.home_team,
         away_team=request.away_team,
         prediction=PredictionDetail(
-            winner=request.home_team,
-            win_probability=0.50,
-            predicted_spread=0.0,
-            confidence="low",
+            winner=winner,
+            win_probability=round(home_win_prob, 4),
+            predicted_spread=0.0,  # spread model not yet trained
+            confidence=_confidence_bucket(home_win_prob),
         ),
-        model_version=settings.VERSION,
+        model_version=meta.get("version", settings.VERSION),
     )
 
 
 @app.get("/model/info", response_model=ModelInfoResponse)
 def model_info() -> ModelInfoResponse:
-    # TODO: Replace stub with actual model metadata
+    try:
+        meta = _manager.model_meta
+    except ModelNotFoundError:
+        return ModelInfoResponse(
+            model_type="none",
+            model_version=settings.VERSION,
+            features_used=0,
+            training_date=None,
+            accuracy=None,
+        )
+
     return ModelInfoResponse(
-        model_type="stub",
-        model_version=settings.VERSION,
-        features_used=0,
-        training_date=None,
-        accuracy=None,
+        model_type=meta.get("model_type", "unknown"),
+        model_version=meta.get("version", settings.VERSION),
+        features_used=len(meta.get("feature_names", [])),
+        training_date=meta.get("train_date"),
+        accuracy=meta.get("metrics", {}).get("accuracy"),
     )

--- a/src/service/features_for_inference.py
+++ b/src/service/features_for_inference.py
@@ -1,0 +1,108 @@
+"""
+Build a single-row feature DataFrame for inference.
+
+Loads season stats for (home_team, away_team) from the DB,
+computes the same diff features used in training.
+"""
+
+import logging
+from typing import Optional
+
+import pandas as pd
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+# Must match the features used in scripts/train_baseline.py
+FEATURE_COLUMNS = [
+    "pf",
+    "pa",
+    "yds_off",
+    "yds_def",
+    "to_off",
+    "to_def",
+    "mov",
+    "srs",
+    "osrs",
+    "dsrs",
+    "win_pct",
+]
+
+
+def _load_team_stats(engine: Engine, team: str, season: int) -> Optional[dict]:
+    """Load aggregated stats for one team in one season."""
+    query = text("""
+        SELECT
+            s.tm,
+            s.pf,
+            s.pa,
+            s.mov,
+            s.srs,
+            s.osrs,
+            s.dsrs,
+            s.win_pct,
+            COALESCE(o.yds, 0) AS yds_off,
+            COALESCE(o.turnovers, 0) AS to_off,
+            COALESCE(d.yds, 0) AS yds_def,
+            COALESCE(d.turnovers, 0) AS to_def
+        FROM standings s
+        LEFT JOIN team_offense o ON s.tm = o.tm AND s.season = o.season
+        LEFT JOIN team_defense d ON s.tm = d.tm AND s.season = d.season
+        WHERE s.season = :season AND s.tm = :team
+        LIMIT 1
+    """)
+    with engine.connect() as conn:
+        result = conn.execute(query, {"season": season, "team": team})
+        row = result.mappings().fetchone()
+
+    if row is None:
+        return None
+    return dict(row)
+
+
+def build_inference_features(
+    engine: Engine,
+    home_team: str,
+    away_team: str,
+    season: int,
+    expected_features: list[str],
+) -> pd.DataFrame:
+    """
+    Build a 1-row DataFrame with diff features (home - away) for prediction.
+
+    Args:
+        engine: SQLAlchemy engine
+        home_team: Home team name (as stored in standings.tm)
+        away_team: Away team name
+        season: Season year
+        expected_features: Feature column names from the trained model
+
+    Returns:
+        DataFrame with one row, columns matching expected_features
+
+    Raises:
+        ValueError: If team stats not found
+    """
+    home_stats = _load_team_stats(engine, home_team, season)
+    away_stats = _load_team_stats(engine, away_team, season)
+
+    if home_stats is None:
+        raise ValueError(f"No stats found for {home_team} in {season}")
+    if away_stats is None:
+        raise ValueError(f"No stats found for {away_team} in {season}")
+
+    row = {}
+    for col in FEATURE_COLUMNS:
+        h_val = float(home_stats.get(col, 0) or 0)
+        a_val = float(away_stats.get(col, 0) or 0)
+        row[f"diff_{col}"] = h_val - a_val
+
+    df = pd.DataFrame([row])
+
+    # Reorder to match model's expected feature order, filling missing with 0
+    for feat in expected_features:
+        if feat not in df.columns:
+            df[feat] = 0.0
+
+    return df[expected_features]

--- a/src/service/model_manager.py
+++ b/src/service/model_manager.py
@@ -1,0 +1,86 @@
+"""
+Model manager: loads the best trained model from the registry and caches it.
+
+Used by the /predictions/predict endpoint for real inference.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from src.models.base_predictor import BasePredictor
+from src.models.model_registry import ModelRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class ModelNotFoundError(Exception):
+    """No trained model artifact is available."""
+
+
+class ModelManager:
+    """Loads and caches the best win/loss model from the registry."""
+
+    def __init__(self, artifacts_path: str):
+        self._artifacts_path = artifacts_path
+        self._model: Optional[BasePredictor] = None
+        self._model_meta: Optional[dict] = None
+
+    @property
+    def model(self) -> BasePredictor:
+        if self._model is None:
+            self._load()
+        return self._model
+
+    @property
+    def model_meta(self) -> dict:
+        if self._model_meta is None:
+            self._load()
+        return self._model_meta
+
+    def _load(self) -> None:
+        """Load the best model from the registry, or a specific one via MODEL_ID env."""
+        registry_path = Path(self._artifacts_path) / "registry.json"
+        if not registry_path.exists():
+            raise ModelNotFoundError(
+                f"No registry.json found at {self._artifacts_path}. "
+                "Train a model first: python scripts/train_baseline.py"
+            )
+
+        registry = ModelRegistry(self._artifacts_path)
+
+        model_id = os.environ.get("MODEL_ID")
+        if model_id:
+            meta = registry.get_model(model_id)
+            if meta is None:
+                raise ModelNotFoundError(f"MODEL_ID={model_id} not found in registry")
+        else:
+            meta = registry.get_best_model("win_loss_classifier", "accuracy")
+            if meta is None:
+                raise ModelNotFoundError(
+                    "No win_loss_classifier models in registry. "
+                    "Train a model first: python scripts/train_baseline.py"
+                )
+
+        artifact_path = Path(self._artifacts_path) / meta["artifact_path"]
+        if not artifact_path.exists():
+            raise ModelNotFoundError(
+                f"Model artifact not found: {artifact_path}. "
+                "Re-train or restore the .joblib file."
+            )
+
+        logger.info(
+            "Loading model %s (accuracy=%.3f) from %s",
+            meta["model_id"],
+            meta["metrics"].get("accuracy", 0),
+            artifact_path,
+        )
+        self._model = BasePredictor.load(str(artifact_path))
+        self._model_meta = meta
+
+    def reload(self) -> None:
+        """Force reload the model (e.g. after re-training)."""
+        self._model = None
+        self._model_meta = None
+        self._load()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,176 @@
+"""
+Tests for model inference: ModelManager, feature builder, and /predictions/predict endpoint.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from src.models.base_predictor import BasePredictor
+from src.models.model_registry import ModelRegistry
+from src.models.win_loss_model import WinLossModel
+from src.service.model_manager import ModelManager, ModelNotFoundError
+
+
+@pytest.fixture
+def trained_model_dir(tmp_path):
+    """Create a temp dir with a trained model and registry."""
+    # Train a tiny model
+    np.random.seed(42)
+    X = pd.DataFrame({
+        "diff_pf": np.random.randn(100),
+        "diff_pa": np.random.randn(100),
+        "diff_mov": np.random.randn(100),
+        "diff_srs": np.random.randn(100),
+    })
+    y = pd.Series(np.random.choice([0, 1], 100))
+
+    model = WinLossModel(model_variant="baseline", version="1.0.0")
+    model.train(X, y)
+
+    # Register and save
+    registry = ModelRegistry(str(tmp_path))
+    model_id = registry.register_model(
+        model_type="win_loss_classifier",
+        model_name="logistic_regression",
+        version="1.0.0",
+        hyperparameters={"C": 1.0},
+        feature_version="1.0.0",
+        train_seasons=[2020, 2021, 2022],
+        test_seasons=[2023],
+        metrics={"accuracy": 0.60, "log_loss": 0.68},
+        feature_names=list(X.columns),
+    )
+    model.save(str(tmp_path / f"{model_id}.joblib"))
+
+    return tmp_path, model_id
+
+
+class TestModelManager:
+    """Tests for ModelManager."""
+
+    def test_loads_best_model(self, trained_model_dir):
+        tmp_path, model_id = trained_model_dir
+        manager = ModelManager(str(tmp_path))
+        m = manager.model
+        assert m.is_trained
+        assert manager.model_meta["model_id"] == model_id
+
+    def test_raises_when_no_registry(self, tmp_path):
+        manager = ModelManager(str(tmp_path))
+        with pytest.raises(ModelNotFoundError, match="No registry.json"):
+            _ = manager.model
+
+    def test_raises_when_no_models(self, tmp_path):
+        # Empty registry
+        registry_file = tmp_path / "registry.json"
+        registry_file.write_text(json.dumps({"models": []}))
+        manager = ModelManager(str(tmp_path))
+        with pytest.raises(ModelNotFoundError, match="No win_loss_classifier"):
+            _ = manager.model
+
+    def test_raises_when_artifact_missing(self, tmp_path):
+        # Registry with entry but no .joblib file
+        registry = ModelRegistry(str(tmp_path))
+        registry.register_model(
+            model_type="win_loss_classifier",
+            model_name="lr",
+            version="1.0.0",
+            hyperparameters={},
+            feature_version="1.0.0",
+            train_seasons=[2020],
+            test_seasons=[2023],
+            metrics={"accuracy": 0.55},
+            feature_names=["f1"],
+        )
+        manager = ModelManager(str(tmp_path))
+        with pytest.raises(ModelNotFoundError, match="artifact not found"):
+            _ = manager.model
+
+
+class TestModelSaveLoad:
+    """Tests for model save/load round-trip."""
+
+    def test_save_and_load(self, tmp_path):
+        np.random.seed(42)
+        X = pd.DataFrame({"a": np.random.randn(50), "b": np.random.randn(50)})
+        y = pd.Series(np.random.choice([0, 1], 50))
+
+        model = WinLossModel(model_variant="baseline")
+        model.train(X, y)
+
+        path = str(tmp_path / "test_model.joblib")
+        model.save(path)
+
+        loaded = BasePredictor.load(path)
+        assert loaded.is_trained
+        assert loaded.feature_names == ["a", "b"]
+
+        # Predictions should be identical
+        orig_pred = model.predict_proba(X)
+        loaded_pred = loaded.predict_proba(X)
+        np.testing.assert_array_equal(orig_pred, loaded_pred)
+
+
+class TestPredictEndpoint:
+    """Tests for /predictions/predict endpoint."""
+
+    def test_returns_503_when_no_model(self):
+        with patch("src.main._manager") as mock_mgr:
+            mock_mgr.model = property(
+                lambda self: (_ for _ in ()).throw(ModelNotFoundError("no model"))
+            )
+            type(mock_mgr).model = property(
+                lambda self: (_ for _ in ()).throw(ModelNotFoundError("no model"))
+            )
+            from src.main import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post(
+                "/predictions/predict",
+                json={"home_team": "KC", "away_team": "BUF", "season": 2023},
+            )
+            assert resp.status_code == 503
+
+    def test_returns_prediction_with_model(self, trained_model_dir):
+        tmp_path, _ = trained_model_dir
+        manager = ModelManager(str(tmp_path))
+
+        with patch("src.main._manager", manager):
+            # Also mock the DB feature builder to return zeros
+            with patch("src.main.build_inference_features") as mock_feat:
+                features = model_features = manager.model.feature_names
+                mock_feat.return_value = pd.DataFrame(
+                    [{f: 0.0 for f in features}]
+                )
+                from src.main import app
+
+                client = TestClient(app)
+                resp = client.post(
+                    "/predictions/predict",
+                    json={"home_team": "KC", "away_team": "BUF", "season": 2023},
+                )
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["home_team"] == "KC"
+                assert data["away_team"] == "BUF"
+                assert "prediction" in data
+                assert "winner" in data["prediction"]
+                assert 0.0 <= data["prediction"]["win_probability"] <= 1.0
+                assert data["prediction"]["confidence"] in ("low", "medium", "high")
+
+    def test_health_endpoint(self):
+        from src.main import app
+
+        client = TestClient(app)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert data["service"] == "beat-books-model"


### PR DESCRIPTION
## Summary
Closes the two biggest gaps blocking scrape→store→predict:

**GAP #2: Training pipeline**
- `scripts/train_baseline.py` trains a logistic regression on season stats from the DB
- Reads standings + team_offense + team_defense tables, builds diff features (home - away)
- Registers model via ModelRegistry, saves `.joblib` artifact

**GAP #3: Real inference**  
- `src/service/model_manager.py` loads best model from registry (by accuracy), caches it
- `src/service/features_for_inference.py` builds 1-row feature DataFrame from DB at inference time
- `/predictions/predict` returns real probabilities, winner, confidence bucket
- `/model/info` returns real model metadata from registry
- Returns HTTP 503 with helpful message when no trained model exists

## How to train a model
```bash
cp .env.example .env
# Set DATABASE_URL to point to beat-books-data DB
python scripts/train_baseline.py --train-seasons 2018-2022 --test-season 2023
```

## Test plan
- [ ] `pytest tests/test_inference.py -v`
- [ ] ModelManager loads model correctly
- [ ] Returns 503 when no artifact exists
- [ ] Returns real prediction with trained model
- [ ] /health endpoint still works